### PR TITLE
Canvas graph componentization

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node-gyp": "^3.8.0",
     "node-watch": "^0.6.0",
     "npm-run-all": "^4.1.5",
+    "pixi.js": "^4.8.7",
     "rxjs": "^6.4.0",
     "vue": "^2.6.8",
     "vue-loader": "^15.7.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="app" :class="mode" :style="appGridStyle" @keydown="onKeyDown">
+    <menu-panel/>
     <transport-bar class="transport-bar app-item"/>
     <transient-editor
       ref="transientEditor"
@@ -30,7 +31,8 @@ export default {
   components: {
     TransportBar,
     TransientEditor,
-    NodeEditor
+    NodeEditor,
+    MenuPanel
   },
   data: () => {
     return {
@@ -137,50 +139,30 @@ export default {
 
 .app {
   height: 100%;
-  display: grid;
-
+  display: flex;
+  flex-direction: column;
   font-family: VarelaRound;
-}
-
-.app.node {
-  /* grid-template-columns: 15em auto; */
-  grid-template-rows: 6em auto;
-}
-.app.midi {
-  /* grid-template-columns: 15em auto; */
-  grid-template-rows: 6em auto;
 }
 
 .app.node > .midi-editor {
   display: none;
 }
-.app.split > .midi-editor {
-  grid-row-end: 3;
-}
 .midi-editor {
-  grid-row-start: 2;
+  flex: 1 1 0;
 }
 
 .transport-bar {
-  grid-row-start: 1;
+  flex: 0 0 30px;
 }
 
 .menu-panel {
-  grid-column-start: 1;
-  grid-row-start: 1;
-}
-.app.node > .node-editor {
-  grid-column-start: 1;
-  grid-row-start: 2;
-  grid-column-end: 2;
-}
-.app.split > .node-editor {
-  grid-column-start: 1;
-  grid-row-start: 3;
-  grid-column-end: 2;
+  flex: 0 0 30px;
 }
 .app.midi > .node-editor {
   display: none;
+}
+.node-editor {
+  flex: 1 1 0;
 }
 
 .app-item {

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,6 @@
       :x-end="viewEnd"
       @noteremove="onRemoveNote"
       @noteresize="onResizeNote"
-      @pan="onMidiEditorPan"
       @zoom="onZoom"
     />
     <node-editor ref="nodeEditor" class="node-editor app-item"/>
@@ -120,10 +119,6 @@ export default {
           1 / 32
         );
       }
-    },
-    onMidiEditorPan({ x }) {
-      this.viewStart += x;
-      this.viewEnd += x;
     },
     onZoom({ x }) {
       const width = this.viewEnd - this.viewStart;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="app" :class="mode" :style="appGridStyle" @keydown="onKeyDown">
-    <menu-panel class="menu-panel app-item"/>
     <transport-bar class="transport-bar app-item"/>
     <transient-editor
       ref="transientEditor"
@@ -31,7 +30,6 @@ export default {
   components: {
     TransportBar,
     TransientEditor,
-    MenuPanel,
     NodeEditor
   },
   data: () => {
@@ -48,7 +46,7 @@ export default {
       // For split mode
       return this.mode === "split"
         ? {
-            gridTemplateColumns: `15em auto`,
+            gridTemplateColumns: `1`,
             gridTemplateRows: `6em ${this.split}fr ${1 - this.split}fr`
           }
         : {};
@@ -58,7 +56,7 @@ export default {
   watch: {
     mode(val) {
       requestAnimationFrame(() => {
-        this.$refs.transientEditor.sizeCanvases();
+        this.$refs.transientEditor.c.sizeCanvases();
         this.$refs.nodeEditor.sizeCanvases();
       });
     }
@@ -145,11 +143,11 @@ export default {
 }
 
 .app.node {
-  grid-template-columns: 15em auto;
+  /* grid-template-columns: 15em auto; */
   grid-template-rows: 6em auto;
 }
 .app.midi {
-  grid-template-columns: 15em auto;
+  /* grid-template-columns: 15em auto; */
   grid-template-rows: 6em auto;
 }
 
@@ -160,13 +158,10 @@ export default {
   grid-row-end: 3;
 }
 .midi-editor {
-  grid-column-start: 1;
   grid-row-start: 2;
-  grid-column-end: 3;
 }
 
 .transport-bar {
-  grid-column-start: 2;
   grid-row-start: 1;
 }
 
@@ -177,19 +172,20 @@ export default {
 .app.node > .node-editor {
   grid-column-start: 1;
   grid-row-start: 2;
-  grid-column-end: 3;
+  grid-column-end: 2;
 }
 .app.split > .node-editor {
   grid-column-start: 1;
   grid-row-start: 3;
-  grid-column-end: 3;
+  grid-column-end: 2;
 }
 .app.midi > .node-editor {
   display: none;
 }
 
 .app-item {
-  background: hsla(0, 0%, 7%, 1);
+  /* background: hsla(0, 0%, 7%, 1); */
+
   color: hsla(0, 0%, 80%, 0.8);
   min-width: 0;
   min-height: 0;

--- a/src/Store.js
+++ b/src/Store.js
@@ -23,6 +23,8 @@ export default () => {
       playbackPosition: 0,
       songStart: 0,
       songEnd: 240,
+      viewStart: 0,
+      viewEnd: 24,
       beatSnap: 1 / 4,
       centsSnap: 100,
       events: {},
@@ -37,6 +39,10 @@ export default () => {
       focus: null,
     },
     mutations: {
+      PAN_TRACK_VIEW(state, { deltaX }) {
+        state.viewStart += deltaX
+        state.viewEnd += deltaX
+      },
       ADD_BRAIN(state, { brain }) {
         Vue.set(state.brains, brain.id, brain)
       },

--- a/src/Store.js
+++ b/src/Store.js
@@ -3,6 +3,7 @@ import Transporter from 'modules/Transporter'
 import inputTracker from './inputTracker'
 import nodeMap from 'nodes'
 import Vue from 'vue'
+import { clamp } from './util'
 
 const lastIds = {
   event: 4,
@@ -42,6 +43,13 @@ export default () => {
       PAN_TRACK_VIEW(state, { deltaX }) {
         state.viewStart += deltaX
         state.viewEnd += deltaX
+      },
+      ZOOM_TRACK_VIEW(state, { x }) {
+        const width = state.viewEnd - state.viewStart
+        const newWidth = clamp(4, x + width, 160)
+        const deltaX = width - newWidth
+        state.viewStart += deltaX / 2
+        state.viewEnd -= deltaX / 2
       },
       ADD_BRAIN(state, { brain }) {
         Vue.set(state.brains, brain.id, brain)

--- a/src/Store.js
+++ b/src/Store.js
@@ -25,7 +25,7 @@ export default () => {
       songStart: 0,
       songEnd: 240,
       viewStart: 0,
-      viewEnd: 24,
+      viewEnd: 4,
       beatSnap: 1 / 4,
       centsSnap: 100,
       events: {},
@@ -87,6 +87,12 @@ export default () => {
         Vue.set(state.events, event.id, event)
         state.tracks[event.trackId].events.push(event.id)
       },
+      REMOVE_EVENT(state, id) {
+        const trackId = state.events[id].trackId
+        const track = state.tracks[trackId]
+        Vue.set(track, 'events', track.events.filter(_id => id !== _id))
+        Vue.delete(state.events, id)
+      },
       SET_EVENT(state, event) {
         Vue.set(state.events, event.id, event)
       },
@@ -147,6 +153,9 @@ export default () => {
       },
     },
     actions: {
+      removeEvents(context, events) {
+        events.forEach(event => context.commit('REMOVE_EVENT', event))
+      },
       addEdge(context, { from, to, input, output }) {
         context.commit('ADD_NODE_EDGE', {
           from,

--- a/src/Store.js
+++ b/src/Store.js
@@ -21,6 +21,8 @@ export default () => {
       transporter: new Transporter(),
       playbackStart: 0,
       playbackPosition: 0,
+      songStart: 0,
+      songEnd: 240,
       beatSnap: 1 / 4,
       centsSnap: 100,
       events: {},

--- a/src/Store.js
+++ b/src/Store.js
@@ -23,7 +23,7 @@ export default () => {
       playbackStart: 0,
       playbackPosition: 0,
       songStart: 0,
-      songEnd: 240,
+      songEnd: 60,
       viewStart: 0,
       viewEnd: 4,
       beatSnap: 1 / 4,

--- a/src/components/CanvasGraph.vue
+++ b/src/components/CanvasGraph.vue
@@ -138,7 +138,7 @@ export default {
       };
     },
     onWheel(e) {
-      this.zoom({
+      this.$emit("zoom", {
         x: e.deltaX / 100,
         y: e.deltaY / 100,
         xOrigin: e.offsetX / this.canvasWidth,

--- a/src/components/CanvasGraph.vue
+++ b/src/components/CanvasGraph.vue
@@ -118,7 +118,7 @@ export default {
 
       if (this.mouseState.includes(1) && this.mouseState.length === 1) {
         const growthFactor = 2.0;
-        this.zoom2d({
+        this.$emit("zoom2d", {
           x: (-e.movementX / this.pxPerX) * growthFactor,
           y: (-e.movementY / this.pxPerY) * growthFactor
         });
@@ -127,7 +127,7 @@ export default {
       const snappedX = this.xSnap ? Math.round(x / this.xSnap) * this.xSnap : x;
       const snappedY = this.ySnap ? Math.round(y / this.ySnap) * this.ySnap : y;
 
-      this.$emit("mousemove", e);
+      this.$emit("mousemove", { e });
       this.$emit("render");
     },
     getMousePosition(e) {

--- a/src/components/CanvasGraph.vue
+++ b/src/components/CanvasGraph.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="node-editor" @mousedown="onMouseDown" @keydown="onKeyDown" @wheel="onWheel">
+    <canvas
+      v-for="layer in layers"
+      ref="edges"
+      :key="layer"
+      class="canvas edges"
+      oncontextmenu="return false"
+      @mousedown="canvasMouseDown"
+    />
+  </div>
+</template>
+
+<script>
+import { mapState } from "vuex";
+
+export default {
+  props: {
+    layers: {
+      type: Array,
+      default: () => "canvas"
+    }
+  },
+  data: () => ({
+    canvasWidth: 300,
+    canvasHeight: 150,
+    dragStart: null,
+    dragEnd: null
+  }),
+  computed: {
+    xCount() {
+      return this.xEnd - this.xStart;
+    },
+    pxPerX() {
+      return this.canvasWidth / this.xCount;
+    },
+    yCount() {
+      return this.yEnd - this.yStart;
+    },
+    pxPerY() {
+      return this.canvasHeight / this.yCount;
+    },
+    contexts() {
+      return this.canvases.map(c => c.getContext("2d"));
+    },
+    ...mapState(["focus"])
+  },
+  methods: {
+    pxOfX(x) {
+      return (x - this.xStart) * this.pxPerX;
+    },
+    pxOfY(y) {
+      return (y - this.yStart) * this.pxPerY;
+    },
+    onKeyDown(e) {
+      this.$emit("keydown", e);
+      this.$emit("render", this.contexts);
+    },
+    onMouseDown(e) {
+      if (e.button === 1) {
+        this.canvases[0].requestPointerLock();
+      }
+
+      const x = e.offsetX;
+      const y = e.offsetY;
+
+      this.dragStart = { x, y };
+      this.dragEnd = { x, y };
+
+      this.mouseDown(e);
+
+      this.render();
+    },
+    onMouseUp(e) {
+      e.preventDefault();
+      if (e.button === 1) document.exitPointerLock();
+      this.dragStart = null;
+      this.dragEnd = null;
+      this.mouseUp(e);
+      this.render();
+    },
+    onMouseMove(e) {
+      if (!this.$el.contains(this.focus)) return;
+      const { x, y } = this.getMousePosition(e);
+
+      if (this.dragStart) this.dragEnd = { x, y };
+
+      if (this.mouseState.includes(2) && this.mouseState.length <= 2) {
+        this.pan({
+          x: -e.movementX / this.pxPerX,
+          y: -e.movementY / this.pxPerY
+        });
+      }
+
+      if (this.mouseState.includes(1) && this.mouseState.length === 1) {
+        const growthFactor = 2.0;
+        this.zoom2d({
+          x: (-e.movementX / this.pxPerX) * growthFactor,
+          y: (-e.movementY / this.pxPerY) * growthFactor
+        });
+      }
+
+      const snappedX = this.xSnap ? Math.round(x / this.xSnap) * this.xSnap : x;
+      const snappedY = this.ySnap ? Math.round(y / this.ySnap) * this.ySnap : y;
+
+      this.mouseMove({ x: snappedX, y: snappedY, e });
+
+      this.render();
+    },
+    getMousePosition(e) {
+      var rect = this.canvases[0].getBoundingClientRect();
+      return {
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top
+      };
+    },
+    onWheel(e) {
+      this.zoom({
+        x: e.deltaX / 100,
+        y: e.deltaY / 100,
+        xOrigin: e.offsetX / this.canvasWidth,
+        yOrigin: e.offsetY / this.canvasHeight
+      });
+    },
+    pxToXY(pxX, pxY) {
+      return [this.pxToX(pxX), this.pxToY(pxY)];
+    },
+    pxToX(pxX) {
+      return pxX / this.pxPerX + this.xStart;
+    },
+    pxToY(pxY) {
+      return pxY / this.pxPerY + this.yStart;
+    },
+    sizeCanvases() {
+      const styles = getComputedStyle(this.canvases[0]);
+      const w = parseInt(styles.getPropertyValue("width"), 10);
+      const h = parseInt(styles.getPropertyValue("height"), 10);
+
+      this.canvases.forEach(canvas => {
+        canvas.width = w;
+        canvas.height = h;
+      });
+
+      this.canvasWidth = w;
+      this.canvasHeight = h;
+
+      this.render();
+    }
+  }
+};
+</script>

--- a/src/components/PixiGraph.vue
+++ b/src/components/PixiGraph.vue
@@ -14,7 +14,10 @@ export default {
     }
   },
   data: () => {
-    let app = new window.PIXI.Application({ transparent: true });
+    let app = new window.PIXI.Application({
+      transparent: true,
+      antialias: true
+    });
     app.renderer.autoResize = true;
     const container = new window.PIXI.Container();
     app.stage.addChild(container);

--- a/src/components/PixiGraph.vue
+++ b/src/components/PixiGraph.vue
@@ -1,0 +1,67 @@
+<template>
+  <div v-once ref="root" class="root"/>
+</template>
+
+<script>
+import "pixi.js";
+
+export default {
+  props: {
+    // [x1, y1, x2, y2]
+    bounds: {
+      type: Array,
+      required: true
+    }
+  },
+  data: () => {
+    let app = new window.PIXI.Application({ transparent: true });
+    app.renderer.autoResize = true;
+    const container = new window.PIXI.Container();
+    app.stage.addChild(container);
+
+    return { app, container, height: 1, width: 1 };
+  },
+  watch: {
+    bounds: {
+      handler(bounds) {
+        this.setContainerTransform();
+      },
+      deep: true
+    },
+    width() {
+      this.setContainerTransform();
+    },
+    height() {
+      this.setContainerTransform();
+    }
+  },
+  mounted() {
+    this.resize();
+    this.$refs.root.appendChild(this.app.view);
+    window.addEventListener("resize", this.resize);
+  },
+  methods: {
+    resize() {
+      const styles = getComputedStyle(this.$refs.root);
+      this.width = parseInt(styles.getPropertyValue("width"), 10);
+      this.height = parseInt(styles.getPropertyValue("height"), 10);
+      this.app.renderer.resize(this.width, this.height);
+      this.setContainerTransform();
+    },
+    setContainerTransform() {
+      const [x1, y1, x2, y2] = this.bounds;
+      const pxPerX = (x2 - x1) / this.width;
+      const pxPerY = (y2 - y1) / this.height;
+      this.container.scale.set(1 / pxPerX, 1 / pxPerY);
+      this.container.position.set(-x1 / pxPerX, -y1 / pxPerY);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.root {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/src/components/TransientEditor.vue
+++ b/src/components/TransientEditor.vue
@@ -1,8 +1,15 @@
 <template>
   <div class="root" ondragstart="return false" :style="{cursor: cursor}" @mousedown="onMouseDown">
-    <canvas ref="background" class="canvas background"/>
-    <canvas ref="notes" class="canvas notes"/>
-    <canvas ref="util" class="canvas util"/>
+    <canvas-graph
+      ref="canvases"
+      :layers="['events']"
+      :x-start="viewStart"
+      :x-end="viewEnd"
+      :y-start="yStart"
+      :y-end="yEnd"
+      @render="render"
+      @pan="pan"
+    />
   </div>
 </template>
 
@@ -12,6 +19,7 @@ import { range } from "lodash";
 import GridLand from "modules/GridLand";
 import { clamp } from "../util";
 import { mapState, mapGetters } from "vuex";
+import CanvasGraph from "components/CanvasGraph.vue";
 
 const dark = 0;
 const light = 1;
@@ -56,16 +64,8 @@ const tools = {
 };
 
 export default {
-  mixins: [GridLand],
+  components: { CanvasGraph },
   props: {
-    xStart: {
-      type: Number,
-      required: true
-    },
-    xEnd: {
-      type: Number,
-      required: true
-    },
     xSnap: {
       type: Number,
       default: () => 1 / 4
@@ -89,8 +89,14 @@ export default {
     pianoNoteHeight() {
       return (this.canvasHeight / this.yCount) * 100;
     },
+    c() {
+      return this.$refs.canvases;
+    },
     canvases() {
-      return [this.$refs.background, this.$refs.notes, this.$refs.util];
+      return this.$refs.canvases.canvases;
+    },
+    contexts() {
+      return this.$refs.canvases.contexts;
     },
     dragTool() {
       if (this.keyboardState.includes("a")) return "resize";
@@ -102,13 +108,13 @@ export default {
       return tools[this.dragTool][key2][key3];
     },
     gradients() {
-      const [backgroundCtx] = this.contexts;
+      const [ctx] = this.contexts;
       return [
-        this.buildBeatMark(backgroundCtx, 0.02, 0, 0.4),
-        this.buildBeatMark(backgroundCtx, 0.03, 100),
-        this.buildBeatMark(backgroundCtx, 0.06, 100),
-        this.buildBeatMark(backgroundCtx, 0.11, 100),
-        this.buildBeatMark(backgroundCtx, 0.3, 100, 0.1)
+        this.buildBeatMark(ctx, 0.02, 0, 0.4),
+        this.buildBeatMark(ctx, 0.03, 100),
+        this.buildBeatMark(ctx, 0.06, 100),
+        this.buildBeatMark(ctx, 0.11, 100),
+        this.buildBeatMark(ctx, 0.3, 100, 0.1)
       ];
     },
     events() {
@@ -124,7 +130,9 @@ export default {
       "mouseState",
       "keyboardState",
       "beatSnap",
-      "centsSnap"
+      "centsSnap",
+      "viewStart",
+      "viewEnd"
     ]),
     ...mapState({
       _transporter: "transporter",
@@ -157,9 +165,9 @@ export default {
     render() {
       // Prepare canvases
       this.contexts.forEach(ctx => {
-        return ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+        return ctx.clearRect(0, 0, this.c.canvasWidth, this.c.canvasHeight);
       });
-      const [backgroundCtx, notesCtx, utilCtx] = this.contexts;
+      const [ctx] = this.contexts;
 
       // Draw piano keys, assume snap is 100, traditional keyboard layout
       const verticalStart =
@@ -168,37 +176,37 @@ export default {
         Math.floor(this.yEnd / this.centsSnap) * this.centsSnap - 50;
 
       const verticalLines = range(verticalStart, verticalEnd, -100);
-      backgroundCtx.fillStyle = `hsla(0, 0%, 0%, 0.2)`;
+      ctx.fillStyle = `hsla(0, 0%, 0%, 0.2)`;
 
       for (const line of verticalLines) {
         let modCents = Math.floor(line % 1200);
         if (modCents < 0) modCents += 1200;
         const noteNumber = modCents / 100;
-        backgroundCtx.fillStyle = this.gradients[pianoNoteColors[noteNumber]];
-        const y = this.pxOfY(line - 50);
+        ctx.fillStyle = this.gradients[pianoNoteColors[noteNumber]];
+        const y = this.c.pxOfY(line - 50);
 
-        backgroundCtx.fillRect(0, y, this.canvasWidth, 100 * this.pxPerY);
+        ctx.fillRect(0, y, this.c.canvasWidth, 100 * this.c.pxPerY);
       }
 
       // Draw beat marks
-      const lines = range(Math.floor(this.xStart), Math.ceil(this.xEnd));
+      const lines = range(Math.floor(this.viewStart), Math.ceil(this.viewEnd));
 
       for (const line of lines) {
-        const pxX = Math.round(this.pxOfX(line));
+        const pxX = Math.round(this.c.pxOfX(line));
 
-        if (pxX < 0 || line > this.xEnd) continue;
+        if (pxX < 0 || line > this.viewEnd) continue;
 
-        backgroundCtx.strokeStyle =
+        ctx.strokeStyle =
           line % 4 === 0
             ? this.gradients[3]
             : line % 2 === 0
             ? this.gradients[2]
             : this.gradients[1];
 
-        backgroundCtx.beginPath();
-        backgroundCtx.moveTo(pxX, 0);
-        backgroundCtx.lineTo(pxX, this.canvasHeight);
-        backgroundCtx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(pxX, 0);
+        ctx.lineTo(pxX, this.c.canvasHeight);
+        ctx.stroke();
       }
 
       const bufferedIds = Object.keys(this.noteBuffer);
@@ -212,21 +220,17 @@ export default {
           2;
         if (hueMod) hueMod += hueMod > 0 ? 10 : -10;
         if (bufferedIds.includes(note.id)) {
-          notesCtx.fillStyle = `hsla(${this.track.hue -
-            hueMod}, 40%, 60%, 0.15)`;
+          ctx.fillStyle = `hsla(${this.track.hue - hueMod}, 40%, 60%, 0.15)`;
         } else if (this.selectedNotes.includes(note.id)) {
-          notesCtx.fillStyle = `hsla(${this.track.hue -
-            hueMod}, 40%, 90%, 0.8)`;
+          ctx.fillStyle = `hsla(${this.track.hue - hueMod}, 40%, 90%, 0.8)`;
         } else {
-          notesCtx.fillStyle = `hsla(${this.track.hue -
-            hueMod}, 30%, 60%, 0.7)`;
+          ctx.fillStyle = `hsla(${this.track.hue - hueMod}, 30%, 60%, 0.7)`;
         }
-        // notesCtx.fillRect
-        notesCtx.fillRect(
-          this.pxOfX(note.beat),
-          this.pxOfY(note.data.pitch - 50),
-          this.pxPerX * note.beats,
-          this.pxPerY * 100
+        ctx.fillRect(
+          this.c.pxOfX(note.beat),
+          this.c.pxOfY(note.data.pitch - 50),
+          this.c.pxPerX * note.beats,
+          this.c.pxPerY * 100
         );
       });
 
@@ -238,25 +242,22 @@ export default {
           2;
         if (hueMod) hueMod += hueMod > 0 ? 10 : -10;
         if (this.selectedNotes.includes(note.id)) {
-          notesCtx.fillStyle = `hsla(${this.track.hue -
-            hueMod}, 40%, 90%, 0.8)`;
+          ctx.fillStyle = `hsla(${this.track.hue - hueMod}, 40%, 90%, 0.8)`;
         } else {
-          notesCtx.fillStyle = `hsla(${this.track.hue -
-            hueMod}, 30%, 60%, 0.7)`;
+          ctx.fillStyle = `hsla(${this.track.hue - hueMod}, 30%, 60%, 0.7)`;
         }
-        // notesCtx.fillRect
-        notesCtx.fillRect(
-          this.pxOfX(note.beat),
-          this.pxOfY(note.data.pitch - 50),
-          this.pxPerX * note.beats,
-          this.pxPerY * 100
+        ctx.fillRect(
+          this.c.pxOfX(note.beat),
+          this.c.pxOfY(note.data.pitch - 50),
+          this.c.pxPerX * note.beats,
+          this.c.pxPerY * 100
         );
       });
 
       if (this.boxSelecting) {
-        utilCtx.strokeStyle = `hsla(0, 0%, 100%, 0.4)`;
+        ctx.strokeStyle = `hsla(0, 0%, 100%, 0.4)`;
         // Draw box selector
-        utilCtx.strokeRect(
+        ctx.strokeRect(
           this.dragStart.x,
           this.dragStart.y,
           this.dragEnd.x - this.dragStart.x,
@@ -264,15 +265,15 @@ export default {
         );
       }
 
-      const cursorX = Math.round(this.pxOfX(this.playbackPosition));
-      utilCtx.strokeStyle = this.gradients[4];
-      utilCtx.beginPath();
-      utilCtx.moveTo(cursorX, 0);
-      utilCtx.lineTo(cursorX, this.canvasHeight);
-      utilCtx.stroke();
+      const cursorX = Math.round(this.c.pxOfX(this.playbackPosition));
+      ctx.strokeStyle = this.gradients[4];
+      ctx.beginPath();
+      ctx.moveTo(cursorX, 0);
+      ctx.lineTo(cursorX, this.c.canvasHeight);
+      ctx.stroke();
     },
     buildBeatMark(ctx, opacity, lightness, spread = 0.15) {
-      var gradient = ctx.createLinearGradient(0, 0, 0, this.canvasHeight);
+      var gradient = ctx.createLinearGradient(0, 0, 0, this.c.canvasHeight);
       gradient.addColorStop("0", `hsla(0, 0%, ${lightness}%, ${opacity / 10})`);
       gradient.addColorStop(spread, `hsla(0, 0%, ${lightness}%, ${opacity})`);
       gradient.addColorStop(
@@ -288,7 +289,7 @@ export default {
     keyDown(e) {
       if (this.keyboardState.includes("q")) this.quantize();
     },
-    mouseDown({ offsetX: x, offsetY: y }) {
+    onMouseDown({ offsetX: x, offsetY: y }) {
       const noteClicked = this.scanForNotes(x, y)[0];
       const { selectedNotes } = this;
 
@@ -312,7 +313,7 @@ export default {
       }
 
       if (!noteClicked) {
-        const [unsnappedBeat, unsnappedPitch] = this.pxToXY(x, y);
+        const [unsnappedBeat, unsnappedPitch] = this.c.pxToXY(x, y);
         const pitch = Math.round(unsnappedPitch / this.ySnap) * this.ySnap;
         const beat = Math.round(unsnappedBeat / this.xSnap) * this.xSnap;
         selectedNotes.splice(0);
@@ -352,13 +353,14 @@ export default {
 
       this.bufferNotes();
     },
-    // global mouseup called by gridland mixin
+
     mouseUp(e) {
       if (this.boxSelecting) {
         this.boxSelectFinish(e);
       }
       this.unbufferNotes();
     },
+
     mouseMove({ e }) {
       const notes = this.scanForNotes(e.offsetX, e.offsetY);
       this.hoveredNotes = notes;
@@ -385,7 +387,7 @@ export default {
           this.resizeTool(xMove, yMove);
         }
       } else if (this.mouseState.includes(0)) {
-        const x = this.pxToX(e.offsetX);
+        const x = this.c.pxToX(e.offsetX);
         const beat = !this.keyboardState.includes("control")
           ? Math.round(x / this.xSnap) * this.xSnap
           : x;
@@ -474,8 +476,8 @@ export default {
       this.render();
     },
     scanBoxForNotes(x1, y1, x2, y2) {
-      let [beat1, pitch1] = this.pxToXY(x1, y1);
-      let [beat2, pitch2] = this.pxToXY(x2, y2);
+      let [beat1, pitch1] = this.c.pxToXY(x1, y1);
+      let [beat2, pitch2] = this.c.pxToXY(x2, y2);
 
       const foundNotes = [];
       for (const noteId of this.track.events) {
@@ -492,7 +494,7 @@ export default {
       return foundNotes;
     },
     scanForNotes(x, y) {
-      let [beat, pitch] = this.pxToXY(x, y);
+      let [beat, pitch] = this.c.pxToXY(x, y);
 
       const foundNotes = [];
       for (const note of Object.values(this.events)) {
@@ -512,7 +514,8 @@ export default {
       if (data.y < 0 && this.yEnd < -1200 * 8) return;
       this.yStart += data.y;
       this.yEnd += data.y;
-      this.$emit("pan", data);
+      // this.$emit("pan", data);
+      this.$store.commit("PAN_TRACK_VIEW", { deltaX: data.x });
       this.render();
     },
     zoom2d(data) {
@@ -533,8 +536,6 @@ export default {
 .root {
   overflow: hidden;
   position: relative;
-  background: hsla(0, 0%, 20%, 1);
-  padding: 0.4em;
 }
 
 .canvas {

--- a/src/components/TransportBar.vue
+++ b/src/components/TransportBar.vue
@@ -10,7 +10,9 @@ import { mapState, mapGetters } from "vuex";
 
 export default {
   components: { PixiGraph },
-  // data: () => {},
+  data: () => ({
+    eventGraphics: {}
+  }),
   computed: {
     bounds() {
       return [this.songStart, 5000, this.songEnd, -5000];
@@ -19,7 +21,26 @@ export default {
   },
   watch: {
     events: {
-      handler() {},
+      handler(events) {
+        for (let eventId of Object.keys(events)) {
+          let eventGraphic = this.eventGraphics[eventId];
+          let event = this.events[eventId];
+          if (!eventGraphic) {
+            eventGraphic = new window.PIXI.Graphics();
+            eventGraphic.beginFill(0x888888);
+            eventGraphic.drawRect(0, 0, event.beats, 100);
+            eventGraphic.endFill();
+            this.$refs.graph.container.addChild(eventGraphic);
+            this.eventGraphics[eventId] = eventGraphic;
+          }
+          eventGraphic.x = event.beat;
+          eventGraphic.y = event.data.pitch;
+        }
+        for (let eventId of Object.keys(this.eventGraphics)) {
+          if (this.events[eventId]) continue;
+          this.$refs.graph.container.removeChild(this.eventGraphics[eventId]);
+        }
+      },
       deep: true
     }
   },
@@ -27,22 +48,34 @@ export default {
     requestAnimationFrame(() => {
       const container = this.$refs.graph.container;
 
-      Object.values(this.events).forEach(event => {
-        const graphic = new window.PIXI.Graphics();
-        graphic.beginFill(0x888888);
-        graphic.drawRect(0, 0, event.beats, 100);
-        graphic.endFill();
-        graphic.x = event.beat;
-        graphic.y = event.data.pitch;
-        this.$refs.graph.container.addChild(graphic);
-        this.$watch(`events.${event.id}`, event => {
-          graphic.x = event.beat;
-          graphic.y = event.data.pitch;
-        });
+      // Object.values(this.events).forEach(event => {
+      //   const graphic = new window.PIXI.Graphics();
+      //   graphic.beginFill(0x888888);
+      //   graphic.drawRect(0, 0, event.beats, 100);
+      //   graphic.endFill();
+      //   graphic.x = event.beat;
+      //   graphic.y = event.data.pitch;
+      //   this.$refs.graph.container.addChild(graphic);
+      //   this.$watch(`events.${event.id}`, event => {
+      //     graphic.x = event.beat;
+      //     graphic.y = event.data.pitch;
+      //   });
+      // });
+
+      let viewStart = new window.PIXI.Graphics();
+      viewStart.beginFill(0x888888, 0.1);
+      viewStart.drawRect(0, -10000, 1, 20000);
+      viewStart.x = this.viewStart;
+      viewStart.scale.set(this.viewEnd - this.viewStart, 1);
+      this.$refs.graph.container.addChild(viewStart);
+      this.$watch(`viewStart`, beat => {
+        viewStart.x = beat;
       });
     });
   },
-  methods: {}
+  methods: {
+    updateViewfinder() {}
+  }
 };
 </script>
 

--- a/src/components/TransportBar.vue
+++ b/src/components/TransportBar.vue
@@ -1,13 +1,54 @@
 <template>
-  <div class="transport-bar"></div>
+  <div>
+    <pixi-graph ref="graph" class="root" :bounds="bounds"/>
+  </div>
 </template>
 
 <script>
-export default {};
+import PixiGraph from "./PixiGraph.vue";
+import { mapState, mapGetters } from "vuex";
+
+export default {
+  components: { PixiGraph },
+  // data: () => {},
+  computed: {
+    bounds() {
+      return [this.songStart, 5000, this.songEnd, -5000];
+    },
+    ...mapState(["songStart", "songEnd", "viewStart", "viewEnd", "events"])
+  },
+  watch: {
+    events: {
+      handler() {},
+      deep: true
+    }
+  },
+  mounted() {
+    requestAnimationFrame(() => {
+      const container = this.$refs.graph.container;
+
+      Object.values(this.events).forEach(event => {
+        const graphic = new window.PIXI.Graphics();
+        graphic.beginFill(0x888888);
+        graphic.drawRect(0, 0, event.beats, 100);
+        graphic.endFill();
+        graphic.x = event.beat;
+        graphic.y = event.data.pitch;
+        this.$refs.graph.container.addChild(graphic);
+        this.$watch(`events.${event.id}`, event => {
+          graphic.x = event.beat;
+          graphic.y = event.data.pitch;
+        });
+      });
+    });
+  },
+  methods: {}
+};
 </script>
 
 <style scoped>
-.transport-bar {
-  padding: 0.4em;
+.root {
+  width: 100%;
+  height: 100%;
 }
 </style>

--- a/src/components/TransportBar.vue
+++ b/src/components/TransportBar.vue
@@ -15,7 +15,7 @@ export default {
   }),
   computed: {
     bounds() {
-      return [this.songStart, 5000, this.songEnd, -5000];
+      return [this.songStart, 3000, this.songEnd, -5000];
     },
     ...mapState(["songStart", "songEnd", "viewStart", "viewEnd", "events"])
   },
@@ -33,6 +33,7 @@ export default {
             this.$refs.graph.container.addChild(eventGraphic);
             this.eventGraphics[eventId] = eventGraphic;
           }
+          console.log(event.beat);
           eventGraphic.x = event.beat;
           eventGraphic.y = event.data.pitch;
         }

--- a/src/inputTracker.js
+++ b/src/inputTracker.js
@@ -5,6 +5,9 @@ export default store => {
   window.addEventListener('keydown', keydown, true)
   window.addEventListener('keyup', keyup, true)
   window.addEventListener('mousemove', mousemove, true)
+  // Keys won't be cleared if user changes focus before releasing a key so we need this
+  //TODO
+  // window.addEventListener('blur', clearKeysState)
 
   function mouseup(e) {
     store.commit('REMOVE_MOUSE_BUTTON', e.button)

--- a/src/modules/GridLand.js
+++ b/src/modules/GridLand.js
@@ -1,4 +1,3 @@
-import { range } from 'lodash'
 import { mapState } from 'vuex'
 
 export default {
@@ -33,8 +32,6 @@ export default {
     window.addEventListener('resize', this.sizeCanvases)
     window.addEventListener('mouseup', this.onMouseUp)
     window.addEventListener('mousemove', this.onMouseMove)
-    // Keys won't be cleared if user changes focus before releasing a key so we need this
-    window.addEventListener('blur', this.clearKeysState)
   },
   beforeDestroy() {
     window.removeEventListener('keydown', this.onKeyDown)
@@ -42,7 +39,6 @@ export default {
     window.removeEventListener('resize', this.sizeCanvases)
     window.removeEventListener('mouseup', this.onMouseUp)
     window.removeEventListener('mousemove', this.onMouseMove)
-    window.removeEventListener('blur', this.clearKeysState)
   },
   methods: {
     pxOfX(x) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,6 +1423,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.0.tgz#9523e001306a32444b907423f1de2164222f6ab1"
   integrity sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==
 
+bit-twiddle@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bit-twiddle/-/bit-twiddle-1.0.2.tgz#0c6c1fabe2b23d17173d9a61b7b7093eb9e1769e"
+  integrity sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4=
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -2357,6 +2362,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+earcut@^2.1.4:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
+  integrity sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -2649,6 +2659,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+eventemitter3@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=
 
 eventemitter3@^3.0.0:
   version "3.1.0"
@@ -3822,6 +3837,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+ismobilejs@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-0.5.1.tgz#0e3f825e29e32f84ad5ddbb60e9e04a894046488"
+  integrity sha512-QX4STsOcBYqlTjVGuAdP1MiRVxtiUbRHOKH0v7Gn1EvfUVIQnrSdgCM4zB4VCZuIejnb2NUMUx0Bwd3EIG6yyA==
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -4743,6 +4763,11 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mini-signals@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mini-signals/-/mini-signals-1.2.0.tgz#45b08013c5fae51a24aa1a935cd317c9ed721d74"
+  integrity sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -5382,6 +5407,11 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
+parse-uri@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-uri/-/parse-uri-1.0.0.tgz#2872dcc22f1a797acde1583d8a0ac29552ddac20"
+  integrity sha1-KHLcwi8aeXrN4Vg9igrClVLdrCA=
+
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
@@ -5524,6 +5554,25 @@ pirates@^4.0.1:
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
+
+pixi-gl-core@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz#8b4b5c433b31e419bc379dc565ce1b835a91b372"
+  integrity sha1-i0tcQzsx5Bm8N53FZc4bg1qRs3I=
+
+pixi.js@^4.8.7:
+  version "4.8.7"
+  resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-4.8.7.tgz#a45c59cdb4dda71f471ecc588301f5ba0f4b77ab"
+  integrity sha512-mx7YbHPkkWoj8FT3qBMkieAjBuuJ4yZWU7rq9NnCSUGpNrVlocrW179xrJQPVR2Q7JZ73ZGTwH7NOUZ9wgh7wA==
+  dependencies:
+    bit-twiddle "^1.0.2"
+    earcut "^2.1.4"
+    eventemitter3 "^2.0.0"
+    ismobilejs "^0.5.1"
+    object-assign "^4.0.1"
+    pixi-gl-core "^1.1.4"
+    remove-array-items "^1.0.0"
+    resource-loader "^2.2.3"
 
 pkg-dir@^3.0.0:
   version "3.0.0"
@@ -5975,6 +6024,11 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
+remove-array-items@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/remove-array-items/-/remove-array-items-1.1.1.tgz#fd745ff73d0822e561ea910bf1b401fc7843e693"
+  integrity sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -6095,6 +6149,14 @@ resolve@^1.10.0, resolve@^1.3.2:
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
   dependencies:
     path-parse "^1.0.6"
+
+resource-loader@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/resource-loader/-/resource-loader-2.2.4.tgz#9bf43dba59475d56be29c796399211ce0e96fd2d"
+  integrity sha512-MrY0bEJN26us3h4bzJUSP0n4tFEb79lCpYBavtLjSezWCcXZMgxhSgvC9LxueuqpcxG+qPjhwFu5SQAcUNacdA==
+  dependencies:
+    mini-signals "^1.1.1"
+    parse-uri "^1.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Explores new options for graph components. Originally, a mixin was created to share graph functionality but that was too tightly coupled to be reusable in the transport bar. Initially the mixin was converted to a component and used in the midi editor. Then I realized pixi.js would be a better option and made a graph component using that for use in the transport bar.

So this leaves three types of graph components being used. They should all be converted to pixi graph components eventually.